### PR TITLE
Fix multiple author on front page

### DIFF
--- a/layouts/partials/li.html
+++ b/layouts/partials/li.html
@@ -12,19 +12,30 @@
             {{$author:= .Params.author}}
             {{if isset .Site.Data.authors $author}}
                 {{$author := index .Site.Data.authors .Params.author }}
+                {{ if isset $author "thumbnail" }}
+                    <img class="author-thumb" src="{{ .Site.BaseURL }}{{ $author.thumbnail }}" alt="Author image" nopin="nopin" />
+                {{else if .Site.Params.logo }}
+                    <img class="author-thumb" src="{{ .Site.BaseURL }}{{.Site.Params.logo}}" alt="Author image" nopin="nopin" />
+                {{end}}
+                {{ if isset $author "name" }}
+                    {{$author.name}}
+                {{else if .Site.Params.author}}
+                    {{.Site.Params.author}}
+                {{end}}
+            {{end}}
+        {{else}}
+            {{ if isset $author "thumbnail" }}
+                <img class="author-thumb" src="{{ .Site.BaseURL }}{{ $author.thumbnail }}" alt="Author image" nopin="nopin" />
+            {{else if .Site.Params.logo }}
+                <img class="author-thumb" src="{{ .Site.BaseURL }}{{.Site.Params.logo}}" alt="Author image" nopin="nopin" />
+            {{end}}
+            {{ if isset $author "name" }}
+                {{$author.name}}
+            {{else if .Site.Params.author}}
+                {{.Site.Params.author}}
             {{end}}
         {{end}}
-
-        {{ if isset $author "thumbnail" }}
-            <img class="author-thumb" src="{{ .Site.BaseURL }}{{ $author.thumbnail }}" alt="Author image" nopin="nopin" />
-        {{else if .Site.Params.logo }}
-            <img class="author-thumb" src="{{ .Site.BaseURL }}{{.Site.Params.logo}}" alt="Author image" nopin="nopin" />
-        {{end}}
-        {{ if isset $author "name" }}
-            {{$author.name}}
-        {{else if .Site.Params.author}}
-            {{.Site.Params.author}}
-        {{end}}
+      
         {{if .Params.tags }}on
             {{ range $index, $tag := .Params.tags }}
                 <a href="{{$baseurl}}tags/{{ $tag | urlize }}/">#{{ $tag }}</a>,


### PR DESCRIPTION
The logic for rendering authors on the front page had issues. The authors set on the post frontmatter were not showing(ignored) as the template logic was trying to override a `$author` variable in a subtle manner.

This fixes the issue and ensures the right author is rendered i.e when the author is set on the frontmatter then he will be picked, and if no author is specified it will default to the site wide author defined in `.Site.Params.author`.